### PR TITLE
libstagefright: enhance rtsp assembler to avoid video stuck in bad wifi ...

### DIFF
--- a/media/libstagefright/rtsp/AAVCAssembler.cpp
+++ b/media/libstagefright/rtsp/AAVCAssembler.cpp
@@ -30,7 +30,7 @@
 #include <stdint.h>
 
 namespace android {
-
+static const size_t kPacketDisorderThresh = 50;
 // static
 AAVCAssembler::AAVCAssembler(const sp<AMessage> &notify)
     : mNotifyMsg(notify),
@@ -73,6 +73,12 @@ ARTPAssembler::AssemblyStatus AAVCAssembler::addNALUnit(
         mNextExpectedSeqNo = (uint32_t)buffer->int32Data();
     } else if ((uint32_t)buffer->int32Data() != mNextExpectedSeqNo) {
         ALOGV("Not the sequence number I expected");
+        // Too much packet lost and waiting for each packet for 10ms will cause video stuck.
+        // directly drop the packets if the lost packets surpasses the thresold
+        if (((uint32_t)buffer->int32Data() - mNextExpectedSeqNo) > kPacketDisorderThresh) {
+            mNextExpectedSeqNo = (uint32_t)buffer->int32Data();
+            return MALFORMED_PACKET;
+        }
 
         return WRONG_SEQUENCE_NUMBER;
     }


### PR DESCRIPTION
...environmemnt

enhance rtsp assembler to avoid video stuck, for too much packet lost and
waiting for each packet for 10ms will cause video stuck.add a disorder threshold
to fix the issue
