### PR TITLE
SoftwareRenderer: Fixes green lines during playback in browsers.

### DIFF
--- a/media/libstagefright/ACodec.cpp
+++ b/media/libstagefright/ACodec.cpp
@@ -1047,6 +1047,10 @@ void ACodec::setNativeWindowColorFormat(OMX_COLOR_FORMATTYPE &eNativeColorFormat
     // In case of Samsung decoders, we set proper native color format for the Native Window
     if (!strcasecmp(mComponentName.c_str(), "OMX.SEC.AVC.Decoder")
         || !strcasecmp(mComponentName.c_str(), "OMX.SEC.FP.AVC.Decoder")
+        || !strcasecmp(mComponentName.c_str(), "OMX.SEC.MPEG4.Decoder")
+        || !strcasecmp(mComponentName.c_str(), "OMX.SEC.H263.Decoder")
+        || !strcasecmp(mComponentName.c_str(), "OMX.SEC.WMV.Decoder")
+        || !strcasecmp(mComponentName.c_str(), "OMX.SEC.VP8.Decoder")
         || !strcasecmp(mComponentName.c_str(), "OMX.Exynos.AVC.Decoder")) {
         switch (eNativeColorFormat) {
             case OMX_COLOR_FormatYUV420SemiPlanar:

--- a/media/libstagefright/colorconversion/SoftwareRenderer.cpp
+++ b/media/libstagefright/colorconversion/SoftwareRenderer.cpp
@@ -225,10 +225,11 @@ void SoftwareRenderer::render(
 
         uint8_t *dst_y = (uint8_t *)dst;
         size_t dst_y_size = buf->stride * buf->height;
-        size_t dst_c_stride = ALIGN(buf->stride / 2, 16);
+        size_t dst_c_stride = buf->stride / 2;
         size_t dst_c_size = dst_c_stride * buf->height / 2;
+        size_t dst_c_size_aligned = ALIGN(buf->stride / 2, 16) * buf->height / 2;
         uint8_t *dst_v = dst_y + dst_y_size;
-        uint8_t *dst_u = dst_v + dst_c_size;
+        uint8_t *dst_u = dst_v + dst_c_size_aligned;
 
         for (int y = 0; y < mCropHeight; ++y) {
             memcpy(dst_y, src_y, mCropWidth);


### PR DESCRIPTION
The UV- components were using a faulty stride value causing the colors to shift 16 bytes per horizontal line.

Change-Id: I5d8614f488e18dc9f9d3ea922baf07222df7fb4c
